### PR TITLE
Revert Estoc to 2H

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.3
+## Estoc 2H Revert
+- Revert Estoc (and named Estoc) to 2H weapon
+    - This means that characters who have the fencer perk (including enemies) will no longer get 3 AP Estoc Lunges
+
 # 0.1.2
 ## Steel Brow Rework
 - Legends reworked Steel Brow in 16.2.4 to convert Stun to Daze whenever a character with Steel Brow receives a Stun.

--- a/mod_ptr_saf_patch/hooks/items/weapons/legend_estoc.nut
+++ b/mod_ptr_saf_patch/hooks/items/weapons/legend_estoc.nut
@@ -1,0 +1,20 @@
+::mods_hookExactClass("items/weapons/legend_estoc", function(o) {
+
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.ItemType = this.Const.Items.ItemType.Weapon | this.Const.Items.ItemType.MeleeWeapon | this.Const.Items.ItemType.TwoHanded;
+		this.setCategories("Sword/Fencing, Two-Handed");
+		this.addWeaponType(this.Const.Items.WeaponType.BFFencing);
+	}
+
+	o.onDeserialize <- function( _in ) {
+		this.weapon.onDeserialize(_in);
+		::PTRSAFPatch.Mod.Debug.printLog("Patching 2H Estoc: deserializing legend_estoc -> " + weapon.getName());
+		this.m.ItemType = this.Const.Items.ItemType.Named | this.Const.Items.ItemType.Weapon | this.Const.Items.ItemType.MeleeWeapon | this.Const.Items.ItemType.TwoHanded;
+		this.setCategories("Sword/Fencing, Two-Handed");
+		this.addWeaponType(this.Const.Items.WeaponType.BFFencing);
+	}
+
+});

--- a/mod_ptr_saf_patch/hooks/items/weapons/named/legend_named_estoc.nut
+++ b/mod_ptr_saf_patch/hooks/items/weapons/named/legend_named_estoc.nut
@@ -1,0 +1,20 @@
+::mods_hookExactClass("items/weapons/named/legend_named_estoc", function(o) {
+
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.ItemType = this.Const.Items.ItemType.Named | this.Const.Items.ItemType.Weapon | this.Const.Items.ItemType.MeleeWeapon | this.Const.Items.ItemType.TwoHanded;
+		this.setCategories("Sword/Fencing, Two-Handed");
+		this.addWeaponType(this.Const.Items.WeaponType.BFFencing);
+	}
+
+	o.onDeserialize <- function( _in ) {
+		this.named_weapon.onDeserialize(_in);
+		::PTRSAFPatch.Mod.Debug.printLog("Patching 2H Estoc: deserializing legend_named_estoc -> " + this.getName());
+		this.m.ItemType = this.Const.Items.ItemType.Named | this.Const.Items.ItemType.Weapon | this.Const.Items.ItemType.MeleeWeapon | this.Const.Items.ItemType.TwoHanded;
+		this.setCategories("Sword/Fencing, Two-Handed");
+		this.addWeaponType(this.Const.Items.WeaponType.BFFencing);
+	}
+
+});

--- a/mod_ptr_saf_patch/load.nut
+++ b/mod_ptr_saf_patch/load.nut
@@ -2,6 +2,11 @@
 ::include("mod_ptr_saf_patch/hooks/config/z_perks_tree_traits.nut");
 ::include("mod_ptr_saf_patch/hooks/config/z_perks_tree_profession.nut");
 
+foreach(file in ::IO.enumerateFiles("mod_ptr_saf_patch/hooks/items"))
+{
+	::include(file);
+}
+
 foreach(file in ::IO.enumerateFiles("mod_ptr_saf_patch/hooks/skills/backgrounds"))
 {
 	::include(file);

--- a/scripts/!mods_preload/mod_ptr_saf_patch.nut
+++ b/scripts/!mods_preload/mod_ptr_saf_patch.nut
@@ -1,5 +1,5 @@
 ::PTRSAFPatch <- {
-	Version = "0.1.2",
+	Version = "0.1.3",
 	ID = "mod_ptr_saf_patch_unofficial",
 	Name = "Unnoficial PTR Smoke And Faith Patch"
 }
@@ -9,6 +9,8 @@
 ::mods_queue(::PTRSAFPatch.ID, "mod_msu(>=1.2.4), mod_legends(>=16.2.3), mod_legends_PTR(=2.1.27)", function() {
 
 	::PTRSAFPatch.Mod <- ::MSU.Class.Mod(::PTRSAFPatch.ID, ::PTRSAFPatch.Version, ::PTRSAFPatch.Name);
+
+	::PTRSAFPatch.Mod.Debug.enable(); // Leave this on by default to help diagnose bug reports
 
 	::PTRSAFPatch.Mod.Registry.addModSource(::MSU.System.Registry.ModSourceDomain.GitHub, "https://github.com/Hanter-19/bb-legends-smoke-and-faith-ptr-patch-unofficial");
 	::PTRSAFPatch.Mod.Registry.setUpdateSource(::MSU.System.Registry.ModSourceDomain.GitHub);


### PR DESCRIPTION
Reverts Estoc to 2H weapon (Legends changed it to 1H weapon but taking up both hand slots) so that Fencer perks work appropriately.