### PR TITLE
Legends 16.3.3 Dynamic Perks Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.2.0
+## Legends 16.3.3
+- **REQUIRES LEGENDS 16.3.3 AND ABOVE ONLY**
+    - If you are running any older version of Legends, do **not** use this version (and future versions) of this patch.
+- Legends team have decided to remove the "dynamic perks" option and make it enabled by default from now on to improve maintainability.
+- This change broke PTR which checks for that option.
+- This fix will patch PTR code to no longer check for that option, which should make PTR playable with Legends 16.3.3
+- Super duper big thanks to Legends dev James Luong for bringing this to my attention, and to Emo Used HM01 for pointing me to the message I missed!!!
+- Note that the other feature changes in Legends 16.3.3, such as background perks, may still be overwritten by PTR 2.1.27 until I release another patch to port those changes over.
+
 # 0.1.3
 ## Estoc 2H Revert
 - Revert Estoc (and named Estoc) to 2H weapon

--- a/mod_ptr_saf_patch/hooks/skills/backgrounds/character_background.nut
+++ b/mod_ptr_saf_patch/hooks/skills/backgrounds/character_background.nut
@@ -1,0 +1,82 @@
+/* 	Override PTR's overrride of buildPerkTree and rebuildPerkTree 
+*	to remove the check for ::Legends.Mod.ModSettings.getSetting("PerkTrees").getValue()
+*	because Legends 16.3.3 has removed the setting (Dynamic Perks is now default)
+*/
+::mods_hookExactClass("skills/backgrounds/character_background", function(o) {
+
+	o.buildPerkTree = function()
+	{
+		local a = {
+			Hitpoints = [
+				0,
+				0
+			],
+			Bravery = [
+				0,
+				0
+			],
+			Stamina = [
+				0,
+				0
+			],
+			MeleeSkill = [
+				0,
+				0
+			],
+			RangedSkill = [
+				0,
+				0
+			],
+			MeleeDefense = [
+				0,
+				0
+			],
+			RangedDefense = [
+				0,
+				0
+			],
+			Initiative = [
+				0,
+				0
+			]
+		};
+
+		if (this.m.PerkTree != null)
+		{
+			return a;
+		}
+
+		if (this.m.CustomPerkTree == null)
+		{
+			local result = this.Const.Perks.GetDynamicPerkTree(this.getPerkTreeDynamicMins(), this.m.PerkTreeDynamic, this.getContainer().getActor());
+			this.m.CustomPerkTree = result.Tree;
+			a = result.Attributes;
+		}
+
+		local pT = this.Const.Perks.BuildCustomPerkTree(this.m.CustomPerkTree);
+		this.m.PerkTree = pT.Tree;
+		this.m.PerkTreeMap = pT.Map;
+
+		local origin = this.World.Assets.getOrigin();
+		if (origin != null)
+		{
+			this.World.Assets.getOrigin().onBuildPerkTree(this);
+		}
+
+		return a;
+	}
+
+	o.rebuildPerkTree = function (_tree)
+	{
+		this.m.CustomPerkTree = _tree;
+
+		// TODO: Might need looking into to make sure if we should be passing this.m.PerkTreeDynamic or something else
+		this.Const.Perks.GetDynamicPerkTree(this.getPerkTreeDynamicMins(), this.m.PerkTreeDynamic, this.getContainer().getActor());
+		this.m.CustomPerkTree = this.Const.Perks.MergeDynamicPerkTree(_tree, this.m.CustomPerkTreeMap);
+
+		local pT = this.Const.Perks.BuildCustomPerkTree(this.m.CustomPerkTree);
+		this.m.PerkTree = pT.Tree;
+		this.m.PerkTreeMap = pT.Map;
+	}
+
+});

--- a/scripts/!mods_preload/mod_ptr_saf_patch.nut
+++ b/scripts/!mods_preload/mod_ptr_saf_patch.nut
@@ -1,12 +1,12 @@
 ::PTRSAFPatch <- {
-	Version = "0.1.3",
+	Version = "0.2.0",
 	ID = "mod_ptr_saf_patch_unofficial",
 	Name = "Unnoficial PTR Smoke And Faith Patch"
 }
 
 ::mods_registerMod(::PTRSAFPatch.ID, ::PTRSAFPatch.Version, ::PTRSAFPatch.Name);
 
-::mods_queue(::PTRSAFPatch.ID, "mod_msu(>=1.2.4), mod_legends(>=16.2.3), mod_legends_PTR(=2.1.27)", function() {
+::mods_queue(::PTRSAFPatch.ID, "mod_msu(>=1.2.4), mod_legends(>=16.3.3), mod_legends_PTR(=2.1.27)", function() {
 
 	::PTRSAFPatch.Mod <- ::MSU.Class.Mod(::PTRSAFPatch.ID, ::PTRSAFPatch.Version, ::PTRSAFPatch.Name);
 


### PR DESCRIPTION
Legends 16.3.3 removed the MSU setting for Dynamic Perks and made Dynamic Perk the default behaviour from now on. PTR still checks for that setting, so this change overrides PTR code to no longer perform the check.