### PR TITLE
Reintroduce Reworked Unarmed Tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
+# 0.3.0
+## Legends 16.4.0+
+** REQUIRES LEGENDS 16.4.0 AND ABOVE ONLY**
+This is because of the newly reworked and reintroduced Unarmed perk tree.
+
+### Unarmed Combat Rework/Reintroduction
+Thanks to Legends Dev James Luong, the Unarmed perk tree has been reworked! PTR removed Unarmed in the past, but since this is an unofficial patch, I'm adding in the reworked Unarmed tree and you can decide for yourself if it fits in well with PTR.
+
+The Unarmed tree will not spawn randomly. It is hard-coded to only and always appear for the following backgrounds:
+- Berserker Commander
+- Brawler
+- Indebted
+- Wildman
+- Wildwoman
+- Berserker from Adventuring Party Origin 
+>Note: this was not in Legends 16.4.0; I think it was an oversight and have raised it with James and am yet to hear back from him. I'm making an executive decision for the Unofficial PTR Patch to include it anyway)
+
+Basically the same as Legends.
+
 # 0.2.0
-## Legends 16.3.3
+## Legends 16.3.3+
 - **REQUIRES LEGENDS 16.3.3 AND ABOVE ONLY**
     - If you are running any older version of Legends, do **not** use this version (and future versions) of this patch.
 - Legends team have decided to remove the "dynamic perks" option and make it enabled by default from now on to improve maintainability.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Battle Brothers Legends Mod Smoke and Faith Update - Unofficial Patch for Perk Trees Rework (PTR) Submod
+# Battle Brothers Legends Mod - Unofficial Patch for Perk Trees Rework (PTR) 2.1.27
 
 ## About
 The Battle Brothers Legends Mod recently released the Smoke and Faith update (16.2.3). So far, there has been no official announcement on whether PTR (currently 2.1.27) will be updated, as the PTR team are busy working on their new overhaul mod. This leaves us with no choice but to wallow in existential dread as we contemplate our increasingly precarious future in these difficult times. I also decided to try making an unofficial patch for fun.

--- a/mod_ptr_saf_patch/hooks/skills/backgrounds/brawler_background.nut
+++ b/mod_ptr_saf_patch/hooks/skills/backgrounds/brawler_background.nut
@@ -1,0 +1,14 @@
+// Only adding FistsClassTree. Everything else unchanged
+::mods_hookExactClass("skills/backgrounds/brawler_background", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+
+		this.m.PerkTreeDynamic = {
+			Class = [
+				::Const.Perks.FistsClassTree // reintroduce reworked Unarmed tree
+			]
+		};
+	}
+});

--- a/mod_ptr_saf_patch/hooks/skills/backgrounds/legend_berserker_background.nut
+++ b/mod_ptr_saf_patch/hooks/skills/backgrounds/legend_berserker_background.nut
@@ -1,0 +1,77 @@
+// Only adding FistsClassTree. Everything else unchanged.
+::mods_hookExactClass("skills/backgrounds/legend_berserker_background", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.CustomPerkTree = ::PTR.HooksHelper.clearCustomPerkTree(this.m.CustomPerkTree);
+
+		::PTR.HooksHelper.addPerkTreesToCustomPerkTree(this.m.CustomPerkTree,
+			[
+				::Const.Perks.AxeTree,
+				::Const.Perks.CleaverTree,
+				::Const.Perks.FlailTree,
+				::Const.Perks.SwordTree,
+				::Const.Perks.TwoHandedTree,
+				::Const.Perks.LightArmorTree,
+				::Const.Perks.ViciousTree,
+				::Const.Perks.ResilientTree,
+				::Const.Perks.LargeTree,
+				::Const.Perks.SturdyTree,
+				::Const.Perks.UnstoppableTree,
+				::Const.Perks.HammerTree,
+				::Const.Perks.FistsClassTree // reintroduce reworked Unarmed tree
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(1, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.BagsAndBelts,
+				::Const.Perks.PerkDefs.Pathfinder,
+				::Const.Perks.PerkDefs.PTRFruitsOfLabor
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(2, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRSavageStrength,
+				::Const.Perks.PerkDefs.PTRMenacing,
+				::Const.Perks.PerkDefs.Anticipation
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(3, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.Sprint,
+				::Const.Perks.PerkDefs.PTRBestialVigor
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(4, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRVigorousAssault,
+				::Const.Perks.PerkDefs.LegendFavouredEnemyGoblin,
+				::Const.Perks.PerkDefs.PTRHaleAndHearty,
+				::Const.Perks.PerkDefs.LegendFavouredEnemyOrk,
+				::Const.Perks.PerkDefs.LegendPoisonImmunity,
+				::Const.Perks.PerkDefs.PTRTheRushOfBattle,
+				::Const.Perks.PerkDefs.PTRBully
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(5, this.m.CustomPerkTree, [
+			::Const.Perks.PerkDefs.BattleFlow,
+			::Const.Perks.PerkDefs.LegendFavouredEnemyUnhold
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(6, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRFreshAndFurious,
+				::Const.Perks.PerkDefs.PTRKnowTheirWeakness
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(7, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRBlitzkrieg,
+				::Const.Perks.PerkDefs.PTRFeralRage,
+				::Const.Perks.PerkDefs.Rebound
+			]
+		);
+	}
+});

--- a/mod_ptr_saf_patch/hooks/skills/backgrounds/legend_berserker_commander_background.nut
+++ b/mod_ptr_saf_patch/hooks/skills/backgrounds/legend_berserker_commander_background.nut
@@ -1,0 +1,78 @@
+// Only adding FistsClassTree. Everything else unchanged.
+::mods_hookExactClass("skills/backgrounds/legend_berserker_commander_background", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+		this.m.CustomPerkTree = ::PTR.HooksHelper.clearCustomPerkTree(this.m.CustomPerkTree);
+
+		::PTR.HooksHelper.addPerkTreesToCustomPerkTree(this.m.CustomPerkTree,
+			[
+				::Const.Perks.AxeTree,
+				::Const.Perks.CleaverTree,
+				::Const.Perks.FlailTree,
+				::Const.Perks.SwordTree,
+				::Const.Perks.TwoHandedTree,
+				::Const.Perks.LightArmorTree,
+				::Const.Perks.ViciousTree,
+				::Const.Perks.ResilientTree,
+				::Const.Perks.LargeTree,
+				::Const.Perks.SturdyTree,
+				::Const.Perks.UnstoppableTree,
+				::Const.Perks.HammerTree,
+				::Const.Perks.FistsClassTree // reintroduce reworked Unarmed tree
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(1, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.BagsAndBelts,
+				::Const.Perks.PerkDefs.Pathfinder,
+				::Const.Perks.PerkDefs.PTRFruitsOfLabor
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(2, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRSavageStrength,
+				::Const.Perks.PerkDefs.PTRMenacing,
+				::Const.Perks.PerkDefs.Anticipation
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(3, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.Sprint,
+				::Const.Perks.PerkDefs.PTRBestialVigor
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(4, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRVigorousAssault,
+				::Const.Perks.PerkDefs.LegendFavouredEnemyGoblin,
+				::Const.Perks.PerkDefs.PTRHaleAndHearty,
+				::Const.Perks.PerkDefs.LegendFavouredEnemyOrk,
+				::Const.Perks.PerkDefs.LegendPoisonImmunity,
+				::Const.Perks.PerkDefs.PTRTheRushOfBattle,
+				::Const.Perks.PerkDefs.PTRBully
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(5, this.m.CustomPerkTree, [
+			::Const.Perks.PerkDefs.BattleFlow,
+			::Const.Perks.PerkDefs.LegendFavouredEnemyUnhold
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(6, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRFreshAndFurious,
+				::Const.Perks.PerkDefs.PTRKnowTheirWeakness
+			]
+		);
+
+		::PTR.HooksHelper.addPerksToCustomPerkTree(7, this.m.CustomPerkTree, [
+				::Const.Perks.PerkDefs.PTRBlitzkrieg,
+				::Const.Perks.PerkDefs.LegendBerserkerRage,
+				::Const.Perks.PerkDefs.Rebound,
+				::Const.Perks.PerkDefs.LegendUberNimble
+			]
+		);
+	}
+});

--- a/mod_ptr_saf_patch/hooks/skills/backgrounds/slave_background.nut
+++ b/mod_ptr_saf_patch/hooks/skills/backgrounds/slave_background.nut
@@ -1,0 +1,17 @@
+// Only adding FistsClassTree. Everything else unchanged.
+::mods_hookExactClass("skills/backgrounds/slave_background", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+
+		this.m.PerkTreeDynamic = {
+			Profession = [
+				::Const.Perks.PauperProfessionTree
+			],
+			Class = [
+				::Const.Perks.FistsClassTree // reintroduce reworked Unarmed tree
+			]
+		};
+	}
+});

--- a/mod_ptr_saf_patch/hooks/skills/backgrounds/wildman_background.nut
+++ b/mod_ptr_saf_patch/hooks/skills/backgrounds/wildman_background.nut
@@ -1,0 +1,20 @@
+// Only adding FistsClassTree. Everything else unchanged.
+::mods_hookExactClass("skills/backgrounds/wildman_background", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+
+		this.m.PerkTreeDynamic = {
+			Profession = [
+				::Const.Perks.WildlingProfessionTree
+			],
+			Styles = [
+				::Const.Perks.TwoHandedTree
+			],
+			Class = [
+				::Const.Perks.FistsClassTree // reintroduce reworked Unarmed tree
+			]
+		};
+	}
+});

--- a/mod_ptr_saf_patch/hooks/skills/backgrounds/wildwoman_background.nut
+++ b/mod_ptr_saf_patch/hooks/skills/backgrounds/wildwoman_background.nut
@@ -1,0 +1,20 @@
+// Only adding FistsClassTree. Everything else unchanged.
+::mods_hookExactClass("skills/backgrounds/wildwoman_background", function(o) {
+	local create = o.create;
+	o.create = function()
+	{
+		create();
+
+		this.m.PerkTreeDynamic = {
+			Profession = [
+				::Const.Perks.WildlingProfessionTree
+			],
+			Styles = [
+				::Const.Perks.TwoHandedTree
+			],
+			Class = [
+				::Const.Perks.FistsClassTree // reintroduce reworked Unarmed tree
+			]
+		};
+	}
+});


### PR DESCRIPTION
Add Unarmed Tree to Berserker Commander, Brawler, Indebted, Wildman, Wildwoman, and Berseker. The last one is a pre-emptive add which wasn't in Legends (I suspect it was an oversight). Regular Berserker is spawned as part of the Adventuring Party Origin.