### PR TITLE
Update internal version to 0.3.1 to remove notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.1
+## Hotfix
+- Hotfix because I am a silly goose and forgot to internally update the version of this mod.
+- If you were playing with 0.3.0 previously and kept getting the notification upon starting the game that a newer version is available, this fix will make that go away.
+- Absolutely no impact on gameplay otherwise; safe to apply to any campaign that already started with 0.3.0.
+- Note that if for any reason you are running an older version of the patch to sustain an ongoing campaign, you will keep getting the notification.
+
 # 0.3.0
 ## Legends 16.4.0+
 ** REQUIRES LEGENDS 16.4.0 AND ABOVE ONLY**

--- a/scripts/!mods_preload/mod_ptr_saf_patch.nut
+++ b/scripts/!mods_preload/mod_ptr_saf_patch.nut
@@ -1,12 +1,12 @@
 ::PTRSAFPatch <- {
-	Version = "0.2.0",
+	Version = "0.3.1",
 	ID = "mod_ptr_saf_patch_unofficial",
 	Name = "Unnoficial PTR Smoke And Faith Patch"
 }
 
 ::mods_registerMod(::PTRSAFPatch.ID, ::PTRSAFPatch.Version, ::PTRSAFPatch.Name);
 
-::mods_queue(::PTRSAFPatch.ID, "mod_msu(>=1.2.4), mod_legends(>=16.3.3), mod_legends_PTR(=2.1.27)", function() {
+::mods_queue(::PTRSAFPatch.ID, "mod_msu(>=1.2.4), mod_legends(>=16.4.0), mod_legends_PTR(=2.1.27)", function() {
 
 	::PTRSAFPatch.Mod <- ::MSU.Class.Mod(::PTRSAFPatch.ID, ::PTRSAFPatch.Version, ::PTRSAFPatch.Name);
 


### PR DESCRIPTION
I released 0.3.0 without updating the version in the code, causing the "new version" MSU notification to show up unnecessarily.